### PR TITLE
Fixing kyc level error

### DIFF
--- a/SilaSDK/src/main/java/com/silamoney/client/domain/HeaderMsg.java
+++ b/SilaSDK/src/main/java/com/silamoney/client/domain/HeaderMsg.java
@@ -37,7 +37,7 @@ public class HeaderMsg {
      * @param appHandle
      */
     public HeaderMsg(String userHandle, String appHandle) {
-        this.kycLevel = "";
+        this.kycLevel = null;
         this.header = new Header(userHandle, appHandle);
         this.message = Message.ValueEnum.HEADER_MSG.getValue();
     }


### PR DESCRIPTION
Previous error: "{"validation_details":{"kyc_level":"This field may not be blank."},"message":"Bad request.","status":"FAILURE"}"