### PR TITLE
Fixed automated sign of package with gpg v>=2.1

### DIFF
--- a/SilaSDK/pom.xml
+++ b/SilaSDK/pom.xml
@@ -105,6 +105,12 @@
 								<goals>
 									<goal>sign</goal>
 								</goals>
+								<configuration>
+									<gpgArguments>
+										<arg>--pinentry-mode</arg>
+										<arg>loopback</arg>
+									</gpgArguments>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>


### PR DESCRIPTION
Fixed error on Azure Pipelines when signing package with gpg:
![image](https://user-images.githubusercontent.com/11563946/87586843-6e8ba780-c69e-11ea-9ca0-166b8401e8fb.png)

It was expecting user to input the passphrase and failed as no user interaction is allowed in azure pipelines.