### PR TITLE
ENGRG-6210 Update projectKey in pom.xml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SONAR_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=Sila-Money_sila-sdk-java -f SilaSDK/pom.xml
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f SilaSDK/pom.xml
   request:
     name: Request reviews on opened PRs
     needs: build

--- a/SilaSDK/pom.xml
+++ b/SilaSDK/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <sonar.projectKey>sila-sdk-java</sonar.projectKey>
+        <sonar.projectKey>Sila-Money_sila-sdk-java</sonar.projectKey>
         <sonar.projectName>sila-sdk-java</sonar.projectName>
         <sonar.coverage.jacoco.xmlReportPaths>**/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <sonar.junit.reportPaths>**/surefire-reports</sonar.junit.reportPaths>


### PR DESCRIPTION
SonarQubePrepare@7 relies on pom.xml to determine the project key, so it must be updated to align with what we have in SonarQube.