### PR TITLE
ENGRG-6352 Migrate Maven deployment to Sonatype Central Portal.

### DIFF
--- a/SilaSDK/pom.xml
+++ b/SilaSDK/pom.xml
@@ -130,13 +130,9 @@
     </dependencies>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+            <id>central</id>
+            <url>https://central.sonatype.com</url>
         </repository>
     </distributionManagement>
 
@@ -212,14 +208,13 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.14</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.9.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
             <plugin>

--- a/SilaSDK/settings.xml
+++ b/SilaSDK/settings.xml
@@ -3,7 +3,7 @@
             http://maven.apache.org/xsd/settings-1.1.0.xsd">
     <servers>
         <server>
-            <id>ossrh</id>
+            <id>central</id>
             <username>#{SONATYPE_USER}#</username>
             <password>#{SONATYPE_PASSWORD}#</password>
         </server>


### PR DESCRIPTION
## Summary
  Update Maven deployment to use new Sonatype Central Portal

  ## Description
  Deployment failing with 401 errors. Need to migrate from deprecated OSSRH (`oss.sonatype.org`) to Central Portal (`central.sonatype.com`).

  ## Changes
  - Update pom.xml: replace `nexus-staging-maven-plugin` with `central-publishing-maven-plugin` v0.9.0
  - Update settings.xml: change server ID from `ossrh` to `central`
  - Update Azure DevOps variables with new tokens from https://central.sonatype.com/usertoken

  ## Reference
  https://central.sonatype.org/publish/publish-portal-maven/